### PR TITLE
fix: Define service start order

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,6 @@ services:
       - MOVE2KUBEAPI=http://move2kubeapi:8080
     ports:
       - "8080:8080"
+    depends_on:
+      - move2kubeapi
+


### PR DESCRIPTION
There could be a possibility of lag within the services when they are spun up so adding a start order will be more defensive to this scenario.

Signed-off-by: K mehant <411843@student.nitandhra.ac.in>