### PR TITLE
fix: upload step in guided flow would move to the next step even without uploading anything

### DIFF
--- a/src/app/Application/GuidedFlow.tsx
+++ b/src/app/Application/GuidedFlow.tsx
@@ -61,7 +61,7 @@ class GuidedFlow extends React.Component<Readonly<unknown>, IGuidedFlowState> {
                         <WizardContextConsumer>
                             {({ onNext }) => (
                                 <>
-                                    <ApplicationAssetUpload update={onNext} /> <Prompt message={navWarn} />
+                                    <ApplicationAssetUpload onNext={onNext} /> <Prompt message={navWarn} />
                                 </>
                             )}
                         </WizardContextConsumer>


### PR DESCRIPTION
This is caused by the 30 second update timer in ApplicationAssetsUpload.
The guided flow is passing the onNext function as the update prop
causing it to jump forward to the next step after 30 seconds.

Signed-off-by: Harikrishnan Balagopal <harikrishmenon@gmail.com>