### PR TITLE
feat: Use docker or podman to build and run the UI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,8 @@ ifneq ($(GIT_TAG),)
 endif
 
 # Setting container tool
-DOCKER_CMD := $(shell command -v docker)
-PODMAN_CMD := $(shell command -v podman)
+DOCKER_CMD := $(shell command -v docker 2> /dev/null)
+PODMAN_CMD := $(shell command -v podman 2> /dev/null)
 
 ifdef DOCKER_CMD
 	CONTAINER_TOOL = 'docker'

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ An UI for interacting with [Move2Kube API](https://github.com/konveyor/move2kube
 ## Starting the UI
 
 1. Build the UI image: `make cbuild`
-2. This uses docker and runs everything inside a single container using the UI image: `make crun`
+2. This uses `docker` or `podman` and runs everything inside a single container using the UI image: `make crun`
 3. Access the UI at http://localhost:8080
 
 For Helm chart and Operator checkout [Move2Kube Operator](https://github.com/konveyor/move2kube-operator).
 
 ## Discussion
 
--   For any questions reach out to us on any of the communication channels given on our website https://move2kube.konveyor.io/.
+- For any questions reach out to us on any of the communication channels given on our website https://move2kube.konveyor.io/.


### PR DESCRIPTION
This PR improves the `Makefile` to check which container tool is installed in the enviroment (only `docker` or `podman`) related with the issue #97.

The user will not have to set up anything before to build or to run the image locally, only a container tool is needed to be installed.

HTH
