### PR TITLE
fix: enable corepack before trying to build in the workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: "16.16.0"
+      - run: corepack enable
       - run: make install
       - run: make build
       - if: failure()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: "16.16.0"
+      - run: corepack enable
       - run: make install
       - run: make build
       - if: failure()

--- a/helm-charts/move2kube/templates/move2kube-api-stateful-set.yaml
+++ b/helm-charts/move2kube/templates/move2kube-api-stateful-set.yaml
@@ -32,7 +32,10 @@ spec:
           command:
             - move2kube-api
           args:
-            - '--config=config.yaml --host="${HOSTNAME}.${MY_SERVICE}"'
+            {{- if .Values.secret.api.enable }}
+            - '--config=config.yaml'
+            {{- end }}
+            - '--host="${HOSTNAME}.${MY_SERVICE}"'
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
@@ -45,10 +48,12 @@ spec:
             privileged: true
           {{- end }}
           volumeMounts:
+            {{- if .Values.secret.api.enable }}
             - name: api-config
               mountPath: /move2kube-api/config.yaml
               subPath: config.yaml
               readOnly: true
+            {{- end }}
             - name: common-volume
               mountPath: /move2kube-api/data
               subPath: move2kube-api/data

--- a/helm-charts/move2kube/values.yaml
+++ b/helm-charts/move2kube/values.yaml
@@ -20,7 +20,7 @@ ingress:
   enable: true
   preferRoute: false # if true we will use an Openshift Route instead of an K8s Ingress
   host: mydomain.com
-  tlsSecretName: myTLSSecret # not necessary when using Openshift Route
+  tlsSecretName: "" # not necessary when using Openshift Route
 persistentVolumeClaim:
   enable: false # set this to true to get persistent storage
   createNew: true


### PR DESCRIPTION
Also allow the helm chart to be deployed without a config.yaml

Signed-off-by: Harikrishnan Balagopal <harikrishmenon@gmail.com>