### PR TITLE
fix: next button in the qa wizard was getting disabled after a successful transformation

### DIFF
--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -25,6 +25,7 @@ import { loginApi } from '../features/login/loginApi';
 import { setupListeners } from '@reduxjs/toolkit/query';
 import inputsReducer from '../features/inputs/inputsSlice';
 import outputsReducer from '../features/outputs/outputsSlice';
+import toastsReducer from '../features/toasts/toastsSlice';
 
 export const store = configureStore({
   reducer: {
@@ -37,6 +38,7 @@ export const store = configureStore({
     [loginApi.reducerPath]: loginApi.reducer,
     inputs: inputsReducer,
     outputs: outputsReducer,
+    toasts: toastsReducer,
   },
   middleware: (getDef) =>
     getDef()

--- a/src/features/outputs/qa/QAWizard.tsx
+++ b/src/features/outputs/qa/QAWizard.tsx
@@ -17,6 +17,7 @@ limitations under the License.
 import { Alert, Button, Spinner, Split, SplitItem, TextContent, Wizard, WizardContextConsumer, WizardStep } from "@patternfly/react-core";
 import { FunctionComponent, useState } from "react";
 import { useAppDispatch, useAppSelector } from "../../../app/hooks";
+import { createToast } from "../../toasts/toastsSlice";
 import { moveToNextQuestion } from "../outputsApi";
 import { updateQAStep, setCurrentStatusId, selectCurrentStatus, TransformationStatus } from "../outputsSlice";
 import { Confirm } from "./Confirm";
@@ -96,14 +97,16 @@ export const QAWizard: FunctionComponent<IQAWizardProps> = (props) => {
                                         try {
                                             if (props.refetch) props.refetch();
                                         } catch (e) {
-                                            console.log('failed to refetch', e);
+                                            console.log('failed to refetch:', e);
                                         }
-                                    } else {
-                                        setIsNextDisabled(false);
+                                        dispatch(createToast({ id: 0, variant: 'success', message: 'Transformation finished.' }));
                                     }
+                                    setIsNextDisabled(false);
                                 })
-                                .catch(console.error);
-                        }}>Next</Button>
+                                .catch((...args) => console.error('failed to move to the next question', ...args));
+                        }}>
+                            Next
+                        </Button>
                     </SplitItem>
                     <SplitItem>
                         <Button variant="secondary" onClick={() => {
@@ -113,7 +116,9 @@ export const QAWizard: FunctionComponent<IQAWizardProps> = (props) => {
                             } catch (e) {
                                 console.log('failed to refetch:', e);
                             }
-                        }}>Cancel</Button>
+                        }}>
+                            Cancel
+                        </Button>
                     </SplitItem>
                     {isNextDisabled && (
                         <SplitItem>

--- a/src/features/toasts/Toasts.tsx
+++ b/src/features/toasts/Toasts.tsx
@@ -14,7 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-export const API_BASE = '/api/v1';
-export const QA_MAX_GET_NEXT_ATTEMPTS = 5;
-export const QA_MILLISECONDS_BETWEEN_GET_NEXT_ATTEMPTS = 3 * 1000;
-export const TOAST_TIMEOUT_MILLISECONDS = 8 * 1000;
+import { AlertGroup } from "@patternfly/react-core";
+import { FunctionComponent } from "react";
+
+export const Toasts: FunctionComponent = () => {
+    return (
+        <AlertGroup></AlertGroup>
+    );
+};

--- a/src/features/toasts/toastsSlice.ts
+++ b/src/features/toasts/toastsSlice.ts
@@ -1,0 +1,59 @@
+/*
+Copyright IBM Corporation 2023
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { RootState } from "../../app/store";
+
+export type ToastVariant = 'success' | 'danger' | 'warning' | 'info' | 'default';
+
+export interface IToast {
+    id: number;
+    variant: ToastVariant;
+    message: string;
+}
+
+export interface IToastsState {
+    nextId: number;
+    toasts: Array<IToast>;
+}
+
+const initialState: IToastsState = {
+    nextId: 0,
+    toasts: [],
+};
+
+export const toastsSlice = createSlice({
+    name: 'toasts',
+    initialState,
+    reducers: {
+        createToast: (state, action: PayloadAction<IToast>) => {
+            state.toasts.push({ ...action.payload, id: state.nextId });
+            state.nextId++;
+        },
+        deleteToast: (state, action: PayloadAction<number>) => {
+            state.toasts = state.toasts.filter(t => t.id !== action.payload);
+        },
+        deleteAllToasts: (state) => {
+            state.toasts = [];
+        },
+    },
+});
+
+export const selectToasts = (state: RootState): Array<IToast> => state.toasts.toasts;
+
+export const { createToast, deleteToast, deleteAllToasts } = toastsSlice.actions;
+
+export default toastsSlice.reducer;


### PR DESCRIPTION
feat: add toasts to signal the creation, updation and deletion of workspaces, projects, etc.
fix: creation/deletion errors should be shown inside the modals instead of outside.

Signed-off-by: Harikrishnan Balagopal <harikrishmenon@gmail.com>