### PR TITLE
fix: helm install with default values.yaml was failing due to permission issue in initContainer on Openshift

### DIFF
--- a/helm-charts/move2kube/templates/move2kube-api-stateful-set.yaml
+++ b/helm-charts/move2kube/templates/move2kube-api-stateful-set.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         move2kube.konveyor.io/service: "{{ .Release.Name }}-move2kubeapi"
     spec:
+      {{- if .Values.persistentVolumeClaim.enable }}
       initContainers:
         - name: change-perms
           image: quay.io/konveyor/busybox
@@ -26,6 +27,7 @@ spec:
             - name: common-volume
               mountPath: /move2kube-api/data
               subPath: move2kube-api/data
+      {{- end }}
       containers:
         - name: move2kubeapi
           image: "quay.io/konveyor/move2kube-ui:{{ .Values.deployment.api.imageTag | default .Chart.AppVersion }}"
@@ -62,7 +64,9 @@ spec:
             {{- end }}
             - name: common-volume
               mountPath: /move2kube-api/data
+              {{- if .Values.persistentVolumeClaim.enable }}
               subPath: move2kube-api/data
+              {{- end }}
             {{- if .Values.deployment.api.privilegedPods }}
             - mountPath: /var/lib/containers
               name: container-storage


### PR DESCRIPTION
```
$ kubectl logs -p move2kube-move2kubeapi-0 -c 'change-perms'
chown: /move2kube-api/data: Operation not permitted
chown: /move2kube-api/data: Operation not permitted
```