### PR TITLE
chore: add a min K8s version to the operator

### DIFF
--- a/operator/.gitignore
+++ b/operator/.gitignore
@@ -27,3 +27,4 @@ coverage.txt
 .cr-release-packages
 secrets/
 /helm-charts/
+/bundle/

--- a/operator/config/manifests/bases/move2kube-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/move2kube-operator.clusterserviceversion.yaml
@@ -80,3 +80,4 @@ spec:
     name: Konveyor
     url: https://konveyor.io
   version: 0.0.0
+  minKubeVersion: 1.22.0


### PR DESCRIPTION
Avoid the warning that Operator Hub gives if
minKubeVersion is not present

Also see https://github.com/k8s-operatorhub/community-operators/blob/3b1a701580e01f5638cad0061ef88dfb85b6e432/operators/konveyor-operator/0.2.1/manifests/konveyor-operator.clusterserviceversion.yaml#L382