### PR TITLE
fix: for Red Hat community prod operators repo we need lower K8s to be compatible with all Openshift versions

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -232,6 +232,17 @@ bundle: kustomize operator-sdk ## Generate bundle manifests and metadata, then v
 	ls -al bundle/
 	ls -al bundle/manifests
 	ls -al bundle/metadata
+	ls -al bundle/metadata/annotations.yaml
+	# -------------------
+	echo 'before adding the annotation required for red hat community prod repo'
+	cat bundle/metadata/annotations.yaml
+	$(eval MYYQEXPR2 := '.annotations."com.redhat.openshift.versions"="v4.1"')
+	echo ${MYYQEXPR2}
+	yq eval --exit-status ${MYYQEXPR2} bundle/metadata/annotations.yaml > foo.yaml
+	mv foo.yaml bundle/metadata/annotations.yaml
+	echo 'after adding the annotation required for red hat community prod repo'
+	cat bundle/metadata/annotations.yaml
+	# -------------------
 
 
 .PHONY: bundle-build

--- a/operator/config/manifests/bases/move2kube-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/move2kube-operator.clusterserviceversion.yaml
@@ -76,7 +76,7 @@ spec:
   - email: seshapad@in.ibm.com
     name: Padmanabha V Seshadri
   maturity: alpha
-  minKubeVersion: 1.22.0
+  minKubeVersion: 1.13.0
   provider:
     name: Konveyor
     url: https://konveyor.io


### PR DESCRIPTION
Also add an annotation to indicate compatible Openshift versions in metadata/annotations.yaml
